### PR TITLE
Fixed the links in the nav on the About page

### DIFF
--- a/_includes/aboutnav.html
+++ b/_includes/aboutnav.html
@@ -2,13 +2,13 @@
 <div class="navbar-inner">
 <h3>The basics</h3>
 <ul class="nav">
-  <li><a href="about.php">What is impact mapping?</a></li>
-  <li><a href="drawing.php">Drawing impact maps</a></li>
-  <li><a href="role.php">Role of impact maps</a></li>
-  <li><a href="example.php">An example</a></li>
-  <li><a href="delivering.php">Delivering business goals, not just features</a></li>
+  <li><a href="about.html">What is impact mapping?</a></li>
+  <li><a href="drawing.html">Drawing impact maps</a></li>
+  <li><a href="role.html">Role of impact maps</a></li>
+  <li><a href="example.html">An example</a></li>
+  <li><a href="delivering.html">Delivering business goals, not just features</a></li>
 </ul>
 <h3>Further info...</h3>
-<a href="book.php" class="btn btn-primary">Get the book</a><br/>&nbsp;
+<a href="book.html" class="btn btn-primary">Get the book</a><br/>&nbsp;
 </div>
 </div>


### PR DESCRIPTION
I haven't tested this, but I'm pretty sure it's right. The actual links on http://www.impactmapping.org/about.html (and other pages) just show the home page.
